### PR TITLE
Removed Deprecations and made usable for julia 1.0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.7
-  - 1
+  - 1.0.3
   - nightly
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
+  - 0.7
+  - 1
   - nightly
 notifications:
   email: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,18 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1
+  - julia_version: nightly
 
-## uncomment the following lines to allow failures on nightly julia
-## (tests will run but not make your overall status red)
-#matrix:
-#  allow_failures:
-#  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-#  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# # Uncomment the following lines to allow failures on nightly julia
+# # (tests will run but not make your overall status red)
+# matrix:
+#   allow_failures:
+#   - julia_version: nightly
 
 branches:
   only:
@@ -24,24 +26,18 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# If there's a newer build queued for the same PR, cancel this one
-  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
-        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
-        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
-        throw "There are newer queued builds for this pull request, failing early." }
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"MultiResolutionIterators\"); Pkg.build(\"MultiResolutionIterators\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"MultiResolutionIterators\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/src/core.jl
+++ b/src/core.jl
@@ -5,7 +5,7 @@ struct NotScalar <: Scalarness end
 isscalar(::Type{Any}) = NotScalar() # if we don't know the type we can't really know if scalar or not
 isscalar(::Type{<:AbstractString}) = NotScalar() # We consider strings to be nonscalar
 isscalar(::Type{<:Number}) = Scalar() # We consider Numbers to be scalar
-isscalar(::Type{Char}) = Scalar() # We consider Sharacter to be scalar
+isscalar(::Type{Char}) = Scalar() # We consider Character to be scalar
 isscalar(::Type{T}) where T = hasmethod(iterate, (T,)) ? NotScalar() : Scalar()
 
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -6,7 +6,7 @@ isscalar(::Type{Any}) = NotScalar() # if we don't know the type we can't really 
 isscalar(::Type{<:AbstractString}) = NotScalar() # We consider strings to be nonscalar
 isscalar(::Type{<:Number}) = Scalar() # We consider Numbers to be scalar
 isscalar(::Type{Char}) = Scalar() # We consider Sharacter to be scalar
-isscalar(::Type{T}) where T = method_exists(start, (T,)) ? NotScalar() : Scalar()
+isscalar(::Type{T}) where T = hasmethod(iterate, (T,)) ? NotScalar() : Scalar()
 
 
 
@@ -46,7 +46,7 @@ function apply_to_interior_levels(ff, iter, lvls, max_depth)
         if cur_level <= max_depth
             # Only expand down if not yet at deepset level we act on
             # (This saves on allocations and time
-            childs = apply(childs) do _childs 
+            childs = apply(childs) do _childs
                 # `apply` needs to be wrapped around all operations, including imap/map
                 imap(_childs) do child
                     inner(child, cur_level+1)
@@ -89,7 +89,7 @@ Applies a op
 If only a single level and a single op is provider,
 then this is identical to `apply_at_level`.
 """
-function apply_at_level(iter, lvl_ops::Associative{<:Integer})
+function apply_at_level(iter, lvl_ops::AbstractDict{<:Integer})
     max_depth = maximum(keys(lvl_ops))
     apply_to_interior_levels(iter, lvl_ops, max_depth) do cur_level, childs
         # if level is a key then  do the thing, else no change

--- a/src/functionality.jl
+++ b/src/functionality.jl
@@ -49,6 +49,6 @@ This is find if they are already strings, or characters, or numbers etc.
 But if they are not, e.g. they were nonmerged layers then this often going to be unusual output.
 But what exactly did you expect it to do? (Answer? Throw an error)
 """
-function join_levels(iter, lvl_delims::Associative)
+function join_levels(iter, lvl_delims::AbstractDict)
     apply_at_level(iter, Dict(lvl => (xs->join(xs,delim))  for (lvl,delim) in lvl_delims))
 end

--- a/src/namedlevels.jl
+++ b/src/namedlevels.jl
@@ -23,7 +23,7 @@ function lvls(indexer, names::Vararg{Symbol})
     name_set = first.(levelname_map(indexer))
     num_set = last.(levelname_map(indexer))
     map(names) do name
-        ind = something(findfirst(isequal(name), name_set), 0)
+        ind = findfirst(isequal(name), name_set)
         num_set[ind]
     end
 end

--- a/src/namedlevels.jl
+++ b/src/namedlevels.jl
@@ -23,7 +23,7 @@ function lvls(indexer, names::Vararg{Symbol})
     name_set = first.(levelname_map(indexer))
     num_set = last.(levelname_map(indexer))
     map(names) do name
-        ind = findfirst(name_set, name)
+        ind = something(findfirst(isequal(name), name_set), 0)
         num_set[ind]
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using MultiResolutionIterators
-using Base.Test
+using Test
 
 
 names = ["basic_functions", "functionality", "namedlevels", "demoscript", "customisability"]

--- a/test/test_basic_functions.jl
+++ b/test/test_basic_functions.jl
@@ -1,5 +1,6 @@
+using Random
 
-srand(1)
+Random.seed!(1)
 len=15
 xss_base = [randstring(len), rand(1:100, len), [randstring(rand(1:10)) for ii=1:len]]
 const xss =  [xss_base; Base.Iterators.flatten.(xss_base)]
@@ -11,4 +12,3 @@ const xss =  [xss_base; Base.Iterators.flatten.(xss_base)]
         end
     end
 end
-

--- a/test/test_customisability.jl
+++ b/test/test_customisability.jl
@@ -1,14 +1,12 @@
-using Base.Test
 using MultiResolutionIterators
+using Test
 
 struct Document{T}
     content::T
 end
 
-
-Base.start(doc::Document)=Base.start(doc.content)
-Base.next(doc::Document, state)=Base.next(doc.content, state)
-Base.done(doc::Document, state)=Base.done(doc.content, state)
+Base.iterate(doc::Document)=iterate(doc.content)
+Base.iterate(doc::Document, state)=iterate(doc.content, state)
 
 Base.length(doc::Document)=Base.length(doc.content)
 

--- a/test/test_functionality.jl
+++ b/test/test_functionality.jl
@@ -1,12 +1,10 @@
 using MultiResolutionIterators
-using Base.Test
+using Test
 using Base.Iterators
 
 
 @testset "basic 1" begin
     eg =   [["aaaa", "bbbb", "ccc"], ["AAA", "BB", "CCC", "DDDDD"], ["111","222"]]
-
-
 
     @testset "join" begin
         @test full_consolidate(join_levels(eg, Dict(2=>" "))) ==
@@ -15,7 +13,6 @@ using Base.Iterators
         @test full_consolidate(join_levels(eg, Dict(1=>"+", 2=>" "))) ==
             full_consolidate("aaaa bbbb ccc+AAA BB CCC DDDDD+111 222")
     end
-
 
     @testset "consolidate" begin
         @test full_consolidate(eg) == eg

--- a/test/test_namedlevels.jl
+++ b/test/test_namedlevels.jl
@@ -1,5 +1,5 @@
 using MultiResolutionIterators
-using Base.Test
+using Test
 
 
 struct OneToOneIndexer end

--- a/test/test_namedlevels.jl
+++ b/test/test_namedlevels.jl
@@ -58,7 +58,7 @@ end
 @testset "ManyToOneIndexer overlap" begin
     indexer = ManyToOneIndexer()
     @testset "lvls" begin
-        @test_throws BoundsError lvls(indexer, :fish)
+        @test_throws ArgumentError lvls(indexer, :fish)
 
         @test lvls(indexer)|>Set == Set()
         @test lvls(indexer, :para)|>Set ==


### PR DESCRIPTION
I have removed the deprecations by running tests in Julia 0.7. It is now able to pass all the tests without any deprecation warnings or any errors.